### PR TITLE
synchrona: add Status LEDs control

### DIFF
--- a/installers/ad-synchrona-14-leds.sh
+++ b/installers/ad-synchrona-14-leds.sh
@@ -1,0 +1,83 @@
+#!bin/bash
+
+HMC7044_STATUS_PATH="/sys/kernel/debug/iio/iio:device0/status"
+AD9545_STATUS_PATH="/sys/kernel/debug/clk/PLL1/PLL1"
+
+RED_LED1=12
+GREEN_LED1=16
+
+STATUS_RED=0
+STATUS_RED_BLINKING=1
+STATUS_GREEN_BLINKING=2
+STATUS_RED_GREEN_BLINKING=3
+STATUS_GREEN=4
+
+LED_STATUS=$STATUS_RED
+AD9545_LOCKED=0
+HMC7044_LOCKED=0
+AD9545_FREERUN=0
+
+while true
+do
+	ad9545_pll_status=$(cat $AD9545_STATUS_PATH)
+	hmc7044_status=$(cat $HMC7044_STATUS_PATH)
+
+	if [[ -z $(echo $ad9545_pll_status | grep -ie Unlocked) ]];
+	then
+		AD9545_LOCKED=1
+	else
+		AD9545_LOCKED=0
+	fi
+
+	if [[ -z $(echo $hmc7044_status | grep -ie Unlocked) ]];
+	then
+		HMC7044_LOCKED=1
+	else
+		HMC7044_LOCKED=0
+	fi
+
+	if [[ -z $(echo $ad9545_pll_status | grep -ie "Freerun Mode: On") ]];
+	then
+		AD9545_FREERUN=0
+	else
+		AD9545_FREERUN=1
+	fi
+
+	if [[ $(( $AD9545_LOCKED & !$AD9545_FREERUN & $HMC7044_LOCKED )) -eq 1 ]]; then
+		LED_STATUS=$STATUS_GREEN
+	elif [[ $(( $AD9545_LOCKED & !$AD9545_FREERUN & !$HMC7044_LOCKED )) -eq 1 ]]; then
+		LED_STATUS=$STATUS_RED_BLINKING
+	elif [[ $(( $AD9545_FREERUN & $HMC7044_LOCKED )) -eq 1 ]]; then
+		LED_STATUS=$STATUS_GREEN_BLINKING
+	elif [[ $(( !$AD9545_LOCKED & !$AD9545_FREERUN & $HMC7044_LOCKED )) -eq 1 ]]; then
+		LED_STATUS=$STATUS_RED_GREEN_BLINKING
+	else
+		LED_STATUS=$STATUS_RED
+	fi
+
+	if [[ $LED_STATUS == $STATUS_GREEN ]]; then
+		echo 0 > "/sys/class/gpio/gpio$RED_LED1/value"
+		echo 1 > "/sys/class/gpio/gpio$GREEN_LED1/value"
+	elif [[ $LED_STATUS == $STATUS_RED_BLINKING ]]; then
+		echo 1 > "/sys/class/gpio/gpio$RED_LED1/value"
+		echo 0 > "/sys/class/gpio/gpio$GREEN_LED1/value"
+		sleep .5
+		echo 0 > "/sys/class/gpio/gpio$RED_LED1/value"
+	elif [[ $LED_STATUS == $STATUS_GREEN_BLINKING ]]; then
+		echo 0 > "/sys/class/gpio/gpio$RED_LED1/value"
+		echo 1 > "/sys/class/gpio/gpio$GREEN_LED1/value"
+		sleep .5
+		echo 0 > "/sys/class/gpio/gpio$GREEN_LED1/value"
+	elif [[ $LED_STATUS == $STATUS_RED_GREEN_BLINKING ]]; then
+		echo 0 > "/sys/class/gpio/gpio$RED_LED1/value"
+		echo 1 > "/sys/class/gpio/gpio$GREEN_LED1/value"
+		sleep .5
+		echo 1 > "/sys/class/gpio/gpio$RED_LED1/value"
+		echo 0 > "/sys/class/gpio/gpio$GREEN_LED1/value"
+	else
+		echo 1 > "/sys/class/gpio/gpio$RED_LED1/value"
+		echo 0 > "/sys/class/gpio/gpio$GREEN_LED1/value"
+	fi
+
+	sleep 1
+done

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -204,10 +204,15 @@ function _setup_synchrona_service() {
     RestartSec=1
     User=root
     ExecStartPre=-/usr/bin/sh -c "/usr/bin/echo 6 > /sys/class/gpio/export"
+    ExecStartPre=-/usr/bin/sh -c "/usr/bin/echo 12 > /sys/class/gpio/export"
+    ExecStartPre=-/usr/bin/sh -c "/usr/bin/echo 16 > /sys/class/gpio/export"
     ExecStartPre=-/usr/bin/dtoverlay -r rpi-ad9545-hmc7044
     ExecStartPre=-/usr/bin/dtoverlay /boot/overlays/rpi-ad9545-hmc7044.dtbo
     ExecStart=/usr/local/bin/uvicorn --app-dir=$tmp/app/python/synchrona  main:app --host 0.0.0.0 --port 8000
+    ExecStartPost=-/usr/bin/bash /etc/raspap/synchrona/ad-synchrona-14-leds.sh > /dev/null 2>&1 &
     ExecStopPost=-/usr/bin/sh -c "/usr/bin/echo 6 > /sys/class/gpio/unexport"
+    ExecStopPost=-/usr/bin/sh -c "/usr/bin/echo 12 > /sys/class/gpio/unexport
+    ExecStopPost=-/usr/bin/sh -c "/usr/bin/echo 16 > /sys/class/gpio/unexport
 
     [Install]
     WantedBy=multi-user.target
@@ -269,6 +274,7 @@ function _create_synchrona_files() {
 
     sudo cp "$webroot_dir/installers/synchrona_ch_modes.txt" "$raspap_dir/synchrona" || _install_status 1 "Unable to move synchrona channels modes"
     sudo cp "$webroot_dir/installers/reload_dtb.sh" "$raspap_dir/synchrona/" || _install_status 1 "Unable to move reload_dtb.sh"
+    sudo cp "$webroot_dir/installers/ad-synchrona-14-leds.sh" "$raspap_dir/synchrona/" || _install_status 1 "Unable to move ad-synchrona-14-leds.sh"
 
     sudo chown -R -c $raspap_user:$raspap_user "$raspap_dir/synchrona/" || _install_status 1 "Unable change owner and/or group"
 


### PR DESCRIPTION
Create a subprocess that handles the LED color based
on the Locking Status of AD9545 and HMC7044.

Signed-off-by: Alexandru Tachici <alexandru.tachici@analog.com>