### PR TITLE
Misc fixes and improvements

### DIFF
--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -529,7 +529,9 @@ function reloadConfig() {
         .then(response => response.json())
         .then(json => {
             if (json == null) {
-                alert("Invalid frequencies");
+                alert("Unknown error! No data returned from the server...");
+            } else if (json.errno_str.length) {
+                alert(json.errno_str);
             } else {
                 setVCXO_TCXO(json.vcxo);
                 for (let i = 1; i <= 14; i++) {

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -542,7 +542,7 @@ function reloadConfig() {
             getConnectionStatus();
         }).
         catch(function(error) {
-            log('Reload failed', error)
+            console.error('Reload failed', error)
             loadingButton(document.getElementById("gen_btnreconfig"), false);
             loadingButton(document.getElementById("adv_btnreconfig"), false);
             getConnectionStatus();

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -649,12 +649,13 @@ function getConnectionStatus() {
 
             document.getElementById("synchronaRefInput").innerHTML = data.input_ref;
 
+            let clkRefClass = document.getElementById("synchronaRefInputStatus").className;
             if (data.pll_locked) {
-                let clkRefClass = document.getElementById("synchronaRefInputStatus").className;
-
                 clkRefClass = clkRefClass.replace(`${STATUS_DISCONNECTED}` , `${STATUS_CONNECTED}`);
-                document.getElementById("synchronaRefInputStatus").className = clkRefClass;
+            } else {
+                clkRefClass = clkRefClass.replace(`${STATUS_CONNECTED}` , `${STATUS_DISCONNECTED}`);
             }
+            document.getElementById("synchronaRefInputStatus").className = clkRefClass;
 
             return ret;
         })

--- a/app/python/synchrona/main.py
+++ b/app/python/synchrona/main.py
@@ -73,6 +73,7 @@ class SynchronaConfig(BaseModel):
     mode: Optional[str]
     input_priority: list
     channels: List[Channel]
+    errno_str: Optional[str]
 
 @app.get("/")
 async def read_root():

--- a/app/python/synchrona/synchrona.py
+++ b/app/python/synchrona/synchrona.py
@@ -431,9 +431,13 @@ def hmc7044_config(config):
             n.remove_property("bias-pull-up")
         if not n.exist_property("bias-pull-down"):
             n.append(Property("bias-pull-down"))
+        if not n.exist_property("output-low"):
+            n.append(Property("output-low"))
     else:
         if n.exist_property("bias-pull-down"):
             n.remove_property("bias-pull-down")
+        if n.exist_property("output-low"):
+            n.remove_property("output-low")
         if not n.exist_property("bias-pull-up"):
             n.append(Property("bias-pull-up"))
         if not n.exist_property("output-high"):

--- a/app/python/synchrona/synchrona.py
+++ b/app/python/synchrona/synchrona.py
@@ -398,7 +398,8 @@ def hmc7044_config(config):
             clk.set_requested_clocks(config.vcxo, output_clocks, clock_names)
             clk.solve()
         except:
-            return None
+            config.errno_str = "Invalid Frequencies: Cannot solve HMC7044 clock configuration..."
+            return config
 
     jif_config = clk.get_config()
 
@@ -523,6 +524,7 @@ def remap_config(config):
 
 def configure_synchrona(config):
     config = remap_config(config)
+    config.errno_str = ""
 
     global driver_modes
     driver_modes = []
@@ -530,7 +532,7 @@ def configure_synchrona(config):
         driver_modes = [line.rstrip() for line in file]
 
     config = hmc7044_config(config)
-    if config is None:
+    if config.errno_str:
         return config
 
     ad9545_config(config)

--- a/app/python/synchrona/synchrona.py
+++ b/app/python/synchrona/synchrona.py
@@ -541,9 +541,6 @@ def configure_synchrona(config):
 
     ad9545_config(config)
 
-    with open("/sys/class/gpio/gpio6/value", "w") as gpio:
-        gpio.write("0" if config.vcxo == 100000000 else "1")
-
     subprocess.call("/etc/raspap/synchrona/reload_dtb.sh")
 
     return config

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -189,8 +189,10 @@ function _install_dependencies() {
 
 function _setup_synchrona_service() {
     local tmp=$webroot_dir
+    local rasp=$raspap_dir
 
     export tmp
+    export rasp
 
     sudo -E bash -c 'cat > /etc/systemd/system/synchrona.service <<- EOM
     [Unit]
@@ -205,8 +207,7 @@ function _setup_synchrona_service() {
     User=root
     ExecStartPre=-/usr/bin/sh -c "/usr/bin/echo 12 > /sys/class/gpio/export"
     ExecStartPre=-/usr/bin/sh -c "/usr/bin/echo 16 > /sys/class/gpio/export"
-    ExecStartPre=-/usr/bin/dtoverlay -r rpi-ad9545-hmc7044
-    ExecStartPre=-/usr/bin/dtoverlay /boot/overlays/rpi-ad9545-hmc7044.dtbo
+    ExecStartPre=-$rasp/synchrona/reload_dtb.sh
     ExecStart=/usr/local/bin/uvicorn --app-dir=$tmp/app/python/synchrona  main:app --host 0.0.0.0 --port 8000
     ExecStartPost=-/usr/bin/bash /etc/raspap/synchrona/ad-synchrona-14-leds.sh > /dev/null 2>&1 &
     ExecStopPost=-/usr/bin/sh -c "/usr/bin/echo 12 > /sys/class/gpio/unexport

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -203,14 +203,12 @@ function _setup_synchrona_service() {
     Restart=always
     RestartSec=1
     User=root
-    ExecStartPre=-/usr/bin/sh -c "/usr/bin/echo 6 > /sys/class/gpio/export"
     ExecStartPre=-/usr/bin/sh -c "/usr/bin/echo 12 > /sys/class/gpio/export"
     ExecStartPre=-/usr/bin/sh -c "/usr/bin/echo 16 > /sys/class/gpio/export"
     ExecStartPre=-/usr/bin/dtoverlay -r rpi-ad9545-hmc7044
     ExecStartPre=-/usr/bin/dtoverlay /boot/overlays/rpi-ad9545-hmc7044.dtbo
     ExecStart=/usr/local/bin/uvicorn --app-dir=$tmp/app/python/synchrona  main:app --host 0.0.0.0 --port 8000
     ExecStartPost=-/usr/bin/bash /etc/raspap/synchrona/ad-synchrona-14-leds.sh > /dev/null 2>&1 &
-    ExecStopPost=-/usr/bin/sh -c "/usr/bin/echo 6 > /sys/class/gpio/unexport"
     ExecStopPost=-/usr/bin/sh -c "/usr/bin/echo 12 > /sys/class/gpio/unexport
     ExecStopPost=-/usr/bin/sh -c "/usr/bin/echo 16 > /sys/class/gpio/unexport
 

--- a/installers/reload_dtb.sh
+++ b/installers/reload_dtb.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
+set -e
 
-dtoverlay -r
+[ -n "$(dtoverlay -l | grep rpi-ad9545-hmc7044)" ] && dtoverlay -r rpi-ad9545-hmc7044
 dtoverlay /boot/overlays/rpi-ad9545-hmc7044.dtbo
-


### PR DESCRIPTION
This patchset adds a number of improvements and some fixes. The main focus was actually on better error handling and report. Often the GUI reload wheel was left spinning indefinitely (meaning an exception in the python service) leaving the user with no clue of what might be wrong. Now all meaningful exceptions should be catched by the service and an error string is returned accordingly...
Other meaningful change is the removal of the vcxo gpio export. Sometimes (don't really know why), the exception "Permission Denied" was being raised when trying to write on the gpio value meaning that, likely, the direction was still as input. Anyways, if everything is properly set in the overlay, we should not really need to export the gpio in the first place as everything should be done by the linux pinctrl subsystem (unless there's some bug there which is not so likely)... We still need to keep an eye on this to make sure that the gpio is always properly set.