### PR TITLE
Staging/synchrona refactor input ref status

### DIFF
--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -156,6 +156,11 @@ i.fa.fa-bars:hover{
   color: #f6f044;
 }
 
+.service-status-light-up {
+  color: #a1ec38;
+  animation: flash 1s linear infinite;
+}
+
 .service-status-down {
   color: #f80107;
   animation: flash 1s linear infinite;

--- a/app/img/synchrona_diagram.svg
+++ b/app/img/synchrona_diagram.svg
@@ -6991,14 +6991,14 @@
        x="87.914993"
        y="75.118195" />
     <rect
-       style="fill:#727272;fill-opacity:0;stroke:#000000;stroke-width:0;stroke-linejoin:round"
+       style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:0.479338;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="VCXO100"
        width="15.520659"
        height="9.5206642"
        x="87.914993"
        y="75.118195" />
     <rect
-       style="fill:#727272;fill-opacity:0.6;stroke:#000000;stroke-width:0;stroke-linejoin:round"
+       style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:0.479338;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="VCXO122"
        width="15.520659"
        height="9.5206642"
@@ -7033,14 +7033,14 @@
        x="35.759167"
        y="112.88962" />
     <rect
-       style="fill:#727272;fill-opacity:0.010022;stroke:#000000;stroke-width:0;stroke-linejoin:round"
+       style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:0.481621;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="TCXO40"
        width="15.520659"
        height="9.5206642"
        x="36.958725"
        y="114.0799" />
     <rect
-       style="fill:#727272;fill-opacity:0.6;stroke:#000000;stroke-width:0;stroke-linejoin:round"
+       style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:0.479338;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        id="TCXO38"
        width="15.520659"
        height="9.5206642"

--- a/app/img/synchrona_diagram.svg
+++ b/app/img/synchrona_diagram.svg
@@ -4219,7 +4219,7 @@
        transform="translate(-261.70513,54.587854)">
       <ellipse
          style="fill:#a61f1f;fill-opacity:1;stroke:none;stroke-width:0.180889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
-         id="path43677-4-7-1-9"
+         id="input_hmc7044_ch3_p"
          cx="271.27954"
          cy="24.946056"
          rx="2.4231153"
@@ -4228,7 +4228,7 @@
          transform="matrix(1.0525629,0,0,1.0496015,-14.283338,-1.2554917)" />
       <ellipse
          style="fill:#a61f1f;fill-opacity:1;stroke:none;stroke-width:0.180889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
-         id="path43677-3-52-67-0-6"
+         id="input_hmc7044_ch3_n"
          cx="271.27954"
          cy="24.946056"
          rx="2.4231153"
@@ -4342,7 +4342,7 @@
        transform="translate(-261.66732,67.687596)">
       <ellipse
          style="fill:#a61f1f;fill-opacity:1;stroke:none;stroke-width:0.180889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
-         id="path43677-4-7-1"
+         id="input_hmc7044_ch2_p"
          cx="271.27954"
          cy="24.946056"
          rx="2.4231153"
@@ -4351,7 +4351,7 @@
          transform="matrix(1.0525629,0,0,1.0496015,-14.283338,-1.2554917)" />
       <ellipse
          style="fill:#a61f1f;fill-opacity:1;stroke:none;stroke-width:0.180889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
-         id="path43677-3-52-67-0"
+         id="input_hmc7044_ch2_n"
          cx="271.27954"
          cy="24.946056"
          rx="2.4231153"
@@ -5687,7 +5687,7 @@
        transform="translate(-261.66945,80.765085)">
       <ellipse
          style="fill:#a61f1f;fill-opacity:1;stroke:none;stroke-width:0.180889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
-         id="path43677-4-7-1-4"
+         id="input_hmc7044_ch1_p"
          cx="271.27954"
          cy="24.946056"
          rx="2.4231153"
@@ -5696,7 +5696,7 @@
          transform="matrix(1.0525629,0,0,1.0496015,-14.283338,-1.2554917)" />
       <ellipse
          style="fill:#a61f1f;fill-opacity:1;stroke:none;stroke-width:0.180889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
-         id="path43677-3-52-67-0-7"
+         id="input_hmc7044_ch1_n"
          cx="271.27954"
          cy="24.946056"
          rx="2.4231153"

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -224,23 +224,25 @@ function isCombinedCMOSChannel(chId) {
     return (chId === '5' || chId === '6' || chId === '7' || chId === '8');
 }
 
+function setAdvancedSvgRectState(elem, en) {
+    if (en) {
+        advancedSvgDocument.getElementById(elem).style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById(elem).style.fillOpacity = 0.350242;
+        advancedSvgDocument.getElementById(elem).style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
+    } else {
+        advancedSvgDocument.getElementById(elem).style.fill = ADVANCED_RECT_FILL_WHITE;
+        advancedSvgDocument.getElementById(elem).style.fillOpacity = 0;
+        advancedSvgDocument.getElementById(elem).style.stroke = ADVANCED_RECT_STROKE_BLACK;
+    }
+}
+
 function setVCXO(vcxo) {
     if (vcxo === 100000000) {
-        advancedSvgDocument.getElementById("VCXO100").style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-        advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0.350242;
-        advancedSvgDocument.getElementById("VCXO100").style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
-
-        advancedSvgDocument.getElementById("VCXO122").style.fill = ADVANCED_RECT_FILL_WHITE;
-        advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0;
-        advancedSvgDocument.getElementById("VCXO122").style.stroke = ADVANCED_RECT_STROKE_BLACK;
+        setAdvancedSvgRectState("VCXO100", true);
+        setAdvancedSvgRectState("VCXO122", false);
     } else {
-        advancedSvgDocument.getElementById("VCXO122").style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-        advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0.350242;
-        advancedSvgDocument.getElementById("VCXO122").style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
-
-        advancedSvgDocument.getElementById("VCXO100").style.fill = ADVANCED_RECT_FILL_WHITE;
-        advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0;
-        advancedSvgDocument.getElementById("VCXO100").style.stroke = ADVANCED_RECT_STROKE_BLACK;
+        setAdvancedSvgRectState("VCXO122", true);
+        setAdvancedSvgRectState("VCXO100", false);
     }
 }
 
@@ -781,21 +783,13 @@ function update_input_references_status(vcxo, pps, ref_in) {
         advancedSvgDocument.getElementById('input_hmc7044_ch3_n').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
     }
 
-    advancedSvgDocument.getElementById('TCXO40').style.fill = ADVANCED_RECT_FILL_WHITE;
-    advancedSvgDocument.getElementById('TCXO40').style.fillOpacity = 0;
-    advancedSvgDocument.getElementById('TCXO40').style.stroke = ADVANCED_RECT_STROKE_BLACK;
-    advancedSvgDocument.getElementById('TCXO38').style.fill = ADVANCED_RECT_FILL_WHITE;
-    advancedSvgDocument.getElementById('TCXO38').style.fillOpacity = 0;
-    advancedSvgDocument.getElementById('TCXO38').style.stroke = ADVANCED_RECT_STROKE_BLACK;
+    setAdvancedSvgRectState("TCXO40", false);
+    setAdvancedSvgRectState("TCXO38", false);
     if (input_ref == "TCXO" && pll_locked) {
         if (vcxo == 122880000) {
-            advancedSvgDocument.getElementById('TCXO38').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-            advancedSvgDocument.getElementById('TCXO38').style.fillOpacity = 0.350242;
-            advancedSvgDocument.getElementById('TCXO38').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
+            setAdvancedSvgRectState("TCXO38", true);
         } else {
-            advancedSvgDocument.getElementById('TCXO40').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-            advancedSvgDocument.getElementById('TCXO40').style.fillOpacity = 0.350242;
-            advancedSvgDocument.getElementById('TCXO40').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
+            setAdvancedSvgRectState("TCXO40", true);
         }
     }
 }

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -97,14 +97,6 @@ advancedSvgElement.addEventListener("load",function(){
         advancedSvgDocument.getElementById(`output_ch${chId}`).addEventListener('click', onChannelClicked);
     }
 
-    // vcxo
-    advancedSvgDocument.getElementById('VCXO100').addEventListener('click', switchVCXO_TCXO);
-    advancedSvgDocument.getElementById('VCXO122').addEventListener('click', switchVCXO_TCXO);
-
-    // tcxo
-    advancedSvgDocument.getElementById('TCXO40').addEventListener('click', switchVCXO_TCXO);
-    advancedSvgDocument.getElementById('TCXO38').addEventListener('click', switchVCXO_TCXO);
-
     // init input
     advancedSvgDocument.getElementById('input_ad9545_internal').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
     advancedSvgDocument.getElementById('input_ad9545_internal').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
@@ -243,23 +235,6 @@ function isCombinedCMOSChannel(chId) {
 
 function setVCXO_TCXO(vcxo) {
     if (vcxo === 100000000) {
-        advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0;
-        advancedSvgDocument.getElementById("TCXO40").style.fillOpacity = 0;
-
-        advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0.6;
-        advancedSvgDocument.getElementById("TCXO38").style.fillOpacity = 0.6;
-    } else {
-        advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0;
-        advancedSvgDocument.getElementById("TCXO38").style.fillOpacity = 0;
-
-        advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0.6;
-        advancedSvgDocument.getElementById("TCXO40").style.fillOpacity = 0.6;
-    }
-}
-
-function switchVCXO_TCXO(event) {
-    let id = event.target.id;
-    if (id === "VCXO100" || id === "TCXO40") {
         advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0;
         advancedSvgDocument.getElementById("TCXO40").style.fillOpacity = 0;
 

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -235,35 +235,23 @@ function isCombinedCMOSChannel(chId) {
     return (chId === '5' || chId === '6' || chId === '7' || chId === '8');
 }
 
-function setVCXO_TCXO(vcxo) {
+function setVCXO(vcxo) {
     if (vcxo === 100000000) {
         advancedSvgDocument.getElementById("VCXO100").style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
         advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0.350242;
         advancedSvgDocument.getElementById("VCXO100").style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
-        advancedSvgDocument.getElementById('TCXO40').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-        advancedSvgDocument.getElementById('TCXO40').style.fillOpacity = 0.350242;
-        advancedSvgDocument.getElementById('TCXO40').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
 
         advancedSvgDocument.getElementById("VCXO122").style.fill = ADVANCED_RECT_FILL_WHITE;
         advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0;
         advancedSvgDocument.getElementById("VCXO122").style.stroke = ADVANCED_RECT_STROKE_BLACK;
-        advancedSvgDocument.getElementById('TCXO38').style.fill = ADVANCED_RECT_FILL_WHITE;
-        advancedSvgDocument.getElementById('TCXO38').style.fillOpacity = 0;
-        advancedSvgDocument.getElementById('TCXO38').style.stroke = ADVANCED_RECT_STROKE_BLACK;
     } else {
         advancedSvgDocument.getElementById("VCXO122").style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
         advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0.350242;
         advancedSvgDocument.getElementById("VCXO122").style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
-        advancedSvgDocument.getElementById('TCXO38').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-        advancedSvgDocument.getElementById('TCXO38').style.fillOpacity = 0.350242;
-        advancedSvgDocument.getElementById('TCXO38').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
 
         advancedSvgDocument.getElementById("VCXO100").style.fill = ADVANCED_RECT_FILL_WHITE;
         advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0;
         advancedSvgDocument.getElementById("VCXO100").style.stroke = ADVANCED_RECT_STROKE_BLACK;
-        advancedSvgDocument.getElementById('TCXO40').style.fill = ADVANCED_RECT_FILL_WHITE;
-        advancedSvgDocument.getElementById('TCXO40').style.fillOpacity = 0;
-        advancedSvgDocument.getElementById('TCXO40').style.stroke = ADVANCED_RECT_STROKE_BLACK;
     }
 }
 
@@ -531,7 +519,7 @@ function reloadConfig() {
             } else if (json.errno_str.length) {
                 alert(json.errno_str);
             } else {
-                setVCXO_TCXO(json.vcxo);
+                setVCXO(json.vcxo);
                 for (let i = 1; i <= 14; i++) {
                     updateDivider(i, json.channels[i-1].divider);
                 }
@@ -767,6 +755,62 @@ Consider restarting your devicetree in the Debug tab...");
     }
 }
 
+function update_input_references_status(vcxo, pps, ref_in) {
+    input_ref = document.getElementById("synchronaRefInput").innerHTML;
+    pll_locked = false;
+
+    if(document.getElementById("synchronaRefInputStatus").className.includes(STATUS_CONNECTED)) {
+        pll_locked = true;
+    }
+
+    if (ref_in) {
+        advancedSvgDocument.getElementById('input_ad9545_ref_in').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+    } else {
+        advancedSvgDocument.getElementById('input_ad9545_ref_in').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+    }
+
+    if (pps) {
+        advancedSvgDocument.getElementById('input_ad9545_pps').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+    } else {
+        advancedSvgDocument.getElementById('input_ad9545_pps').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+    }
+
+    if (input_ref == "REF_CLK" && pll_locked) {
+        advancedSvgDocument.getElementById('input_hmc7044_ch2_p').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById('input_hmc7044_ch2_n').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+        return
+    } else {
+        advancedSvgDocument.getElementById('input_hmc7044_ch2_p').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+        advancedSvgDocument.getElementById('input_hmc7044_ch2_n').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+    }
+
+    if (input_ref == "P_CH3" && pll_locked) {
+        advancedSvgDocument.getElementById('input_hmc7044_ch3_p').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById('input_hmc7044_ch3_n').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+    } else {
+        advancedSvgDocument.getElementById('input_hmc7044_ch3_p').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+        advancedSvgDocument.getElementById('input_hmc7044_ch3_n').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+    }
+
+    advancedSvgDocument.getElementById('TCXO40').style.fill = ADVANCED_RECT_FILL_WHITE;
+    advancedSvgDocument.getElementById('TCXO40').style.fillOpacity = 0;
+    advancedSvgDocument.getElementById('TCXO40').style.stroke = ADVANCED_RECT_STROKE_BLACK;
+    advancedSvgDocument.getElementById('TCXO38').style.fill = ADVANCED_RECT_FILL_WHITE;
+    advancedSvgDocument.getElementById('TCXO38').style.fillOpacity = 0;
+    advancedSvgDocument.getElementById('TCXO38').style.stroke = ADVANCED_RECT_STROKE_BLACK;
+    if (input_ref == "TCXO" && pll_locked) {
+        if (vcxo == 122880000) {
+            advancedSvgDocument.getElementById('TCXO38').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+            advancedSvgDocument.getElementById('TCXO38').style.fillOpacity = 0.350242;
+            advancedSvgDocument.getElementById('TCXO38').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
+        } else {
+            advancedSvgDocument.getElementById('TCXO40').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+            advancedSvgDocument.getElementById('TCXO40').style.fillOpacity = 0.350242;
+            advancedSvgDocument.getElementById('TCXO40').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
+        }
+    }
+}
+
 function updateValuesAdvanced(data) {
     pll2Freq = data["channels"][0].frequency * data["channels"][0].divider;
 
@@ -787,8 +831,9 @@ function updateValuesAdvanced(data) {
         updateCoarseDelayRange(advancedSvgDocument, i, pll2Freq);
         updateFineDelayGeneric(advancedSvgDocument, i, fineDelayFromDTValue(ch.fine_delay));
     }
-    setVCXO_TCXO(data["vcxo"]);
+    setVCXO(data["vcxo"]);
     update_input_priorities(data["input_priorities"])
+    update_input_references_status(data["vcxo"], data["pps"], data["ref_in"]);
 }
 
 function setInputPriorityVisibility(id, visible) {

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -509,22 +509,20 @@ function reloadConfig() {
                 alert("Unknown error! No data returned from the server...");
             } else if (json.errno_str.length) {
                 alert(json.errno_str);
-            } else {
-                setVCXO(json.vcxo);
-                for (let i = 1; i <= 14; i++) {
-                    updateDivider(i, json.channels[i-1].divider);
-                }
             }
+
             loadingButton(document.getElementById("gen_btnreconfig"), false);
             loadingButton(document.getElementById("adv_btnreconfig"), false);
             console.info('Synchrona updated');
             getConnectionStatus();
+            updateAllMenus();
         }).
         catch(function(error) {
             console.error('Reload failed', error)
             loadingButton(document.getElementById("gen_btnreconfig"), false);
             loadingButton(document.getElementById("adv_btnreconfig"), false);
             getConnectionStatus();
+            updateAllMenus();
         });
 }
 
@@ -701,6 +699,18 @@ function updateAdvancedMenu() {
         if (data == null) {
             return false;
         }
+        updateValuesAdvanced(data);
+        return true;
+    });
+}
+
+function updateAllMenus() {
+    getSynchronaData()
+    .then(data => {
+        if (data == null) {
+            return false;
+        }
+        updateValuesGeneral(data);
         updateValuesAdvanced(data);
         return true;
     });

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -102,17 +102,6 @@ advancedSvgElement.addEventListener("load",function(){
     // init input
     advancedSvgDocument.getElementById('input_ad9545_internal').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
     advancedSvgDocument.getElementById('input_ad9545_internal').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
-    advancedSvgDocument.getElementById('input_ad9545_sync').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
-    advancedSvgDocument.getElementById('input_ad9545_pps').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-    advancedSvgDocument.getElementById('input_ad9545_ref_in').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-    advancedSvgDocument.getElementById('ref_out').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch3_p').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch3_n').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch2_p').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch2_n').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch1_p').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch1_n').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
-
 
     for (let chId = 1; chId <= 14; chId++) {
         advancedSvgDocument.getElementById(`frequency_ch${chId}`).addEventListener('change', advancedMenuUpdateFrequency);

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -111,9 +111,13 @@ advancedSvgElement.addEventListener("load",function(){
     advancedSvgDocument.getElementById('input_ad9545_pps').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
     advancedSvgDocument.getElementById('input_ad9545_ref_in').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
     advancedSvgDocument.getElementById('ref_out').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch3').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch2').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
-    advancedSvgDocument.getElementById('input_hmc7044_ch1').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+    advancedSvgDocument.getElementById('input_hmc7044_ch3_p').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+    advancedSvgDocument.getElementById('input_hmc7044_ch3_n').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+    advancedSvgDocument.getElementById('input_hmc7044_ch2_p').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+    advancedSvgDocument.getElementById('input_hmc7044_ch2_n').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+    advancedSvgDocument.getElementById('input_hmc7044_ch1_p').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+    advancedSvgDocument.getElementById('input_hmc7044_ch1_n').style.fill = ADVANCED_CHANNEL_DISABLE_COLOR;
+
 
     for (let chId = 1; chId <= 14; chId++) {
         advancedSvgDocument.getElementById(`frequency_ch${chId}`).addEventListener('change', advancedMenuUpdateFrequency);

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -6,6 +6,8 @@ const STATUS_DISCONNECTED = 'service-status-down';
 
 const ADVANCED_CHANNEL_ENABLE_COLOR = 'rgb(44, 107, 27)';
 const ADVANCED_CHANNEL_DISABLE_COLOR = 'rgb(166, 31, 31)';
+const ADVANCED_RECT_FILL_WHITE  = 'rgb(255, 255, 255)';
+const ADVANCED_RECT_STROKE_BLACK  = 'rgb(0, 0, 0)';
 
 const SELECT_STROKE = '0.7px';
 const DESELECT_STROKE = '0px';
@@ -235,17 +237,33 @@ function isCombinedCMOSChannel(chId) {
 
 function setVCXO_TCXO(vcxo) {
     if (vcxo === 100000000) {
-        advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0;
-        advancedSvgDocument.getElementById("TCXO40").style.fillOpacity = 0;
+        advancedSvgDocument.getElementById("VCXO100").style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0.350242;
+        advancedSvgDocument.getElementById("VCXO100").style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById('TCXO40').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById('TCXO40').style.fillOpacity = 0.350242;
+        advancedSvgDocument.getElementById('TCXO40').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
 
-        advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0.6;
-        advancedSvgDocument.getElementById("TCXO38").style.fillOpacity = 0.6;
-    } else {
+        advancedSvgDocument.getElementById("VCXO122").style.fill = ADVANCED_RECT_FILL_WHITE;
         advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0;
-        advancedSvgDocument.getElementById("TCXO38").style.fillOpacity = 0;
+        advancedSvgDocument.getElementById("VCXO122").style.stroke = ADVANCED_RECT_STROKE_BLACK;
+        advancedSvgDocument.getElementById('TCXO38').style.fill = ADVANCED_RECT_FILL_WHITE;
+        advancedSvgDocument.getElementById('TCXO38').style.fillOpacity = 0;
+        advancedSvgDocument.getElementById('TCXO38').style.stroke = ADVANCED_RECT_STROKE_BLACK;
+    } else {
+        advancedSvgDocument.getElementById("VCXO122").style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById("VCXO122").style.fillOpacity = 0.350242;
+        advancedSvgDocument.getElementById("VCXO122").style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById('TCXO38').style.fill = ADVANCED_CHANNEL_ENABLE_COLOR;
+        advancedSvgDocument.getElementById('TCXO38').style.fillOpacity = 0.350242;
+        advancedSvgDocument.getElementById('TCXO38').style.stroke = ADVANCED_CHANNEL_ENABLE_COLOR;
 
-        advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0.6;
-        advancedSvgDocument.getElementById("TCXO40").style.fillOpacity = 0.6;
+        advancedSvgDocument.getElementById("VCXO100").style.fill = ADVANCED_RECT_FILL_WHITE;
+        advancedSvgDocument.getElementById("VCXO100").style.fillOpacity = 0;
+        advancedSvgDocument.getElementById("VCXO100").style.stroke = ADVANCED_RECT_STROKE_BLACK;
+        advancedSvgDocument.getElementById('TCXO40').style.fill = ADVANCED_RECT_FILL_WHITE;
+        advancedSvgDocument.getElementById('TCXO40').style.fillOpacity = 0;
+        advancedSvgDocument.getElementById('TCXO40').style.stroke = ADVANCED_RECT_STROKE_BLACK;
     }
 }
 
@@ -550,7 +568,7 @@ function getJSON() {
 }
 
 function getVCXO() {
-    if ( advancedSvgDocument.getElementById("VCXO100").style.fillOpacity === "0") {
+    if ( advancedSvgDocument.getElementById("VCXO100").style.fill === ADVANCED_CHANNEL_ENABLE_COLOR) {
         return 100000000;
     }
     return 122880000;

--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -1,5 +1,6 @@
 
 const STATUS_CONNECTED = 'service-status-up';
+const STATUS_LIGHT_CONNECTED ='service-status-light-up'
 const STATUS_WARN = 'service-status-warn';
 const STATUS_DISCONNECTED = 'service-status-down';
 
@@ -622,6 +623,12 @@ function getConnectionStatus() {
     synchronaDtClass = synchronaDtClass.replace(`${STATUS_WARN}` , '');
     synchronaDtClass = synchronaDtClass.replace(`${STATUS_DISCONNECTED}` , '');
 
+    let clkRefClass = document.getElementById("synchronaRefInputStatus").className;
+    clkRefClass = clkRefClass.replace(`${STATUS_CONNECTED}`, '');
+    clkRefClass = clkRefClass.replace(`${STATUS_LIGHT_CONNECTED}`, '');
+    clkRefClass = clkRefClass.replace(`${STATUS_WARN}`, '');
+    clkRefClass = clkRefClass.replace(`${STATUS_DISCONNECTED}`, '');
+
     return fetch(`http://${ipAddress}:8000/synchrona/status`)
         .then(handleErrors)
         .then(response => {
@@ -655,11 +662,18 @@ function getConnectionStatus() {
 
             document.getElementById("synchronaRefInput").innerHTML = data.input_ref;
 
-            let clkRefClass = document.getElementById("synchronaRefInputStatus").className;
             if (data.pll_locked) {
-                clkRefClass = clkRefClass.replace(`${STATUS_DISCONNECTED}` , `${STATUS_CONNECTED}`);
+                if (data.input_ref == "OCXO") {
+                    clkRefClass += `${STATUS_LIGHT_CONNECTED}`;
+                } else if(data.input_ref == "Holdover") {
+                    clkRefClass += `${STATUS_WARN}`;
+                    alert("Holdover mode on! This means that a valid reference was lost... \
+Press 'Reload config' if you want to switch to the internal OCXO.")
+                } else {
+                    clkRefClass += `${STATUS_CONNECTED}`
+                }
             } else {
-                clkRefClass = clkRefClass.replace(`${STATUS_CONNECTED}` , `${STATUS_DISCONNECTED}`);
+                clkRefClass += `${STATUS_DISCONNECTED}`;
             }
             document.getElementById("synchronaRefInputStatus").className = clkRefClass;
 

--- a/app/python/synchrona/main.py
+++ b/app/python/synchrona/main.py
@@ -86,7 +86,7 @@ async def get_channels():
 
 class input_reference():
     def __init__(self):
-        self.ref = "unknown"
+        self.ref = "Unknown"
         self.locked = False
 
 @app.get("/synchrona/status")

--- a/app/python/synchrona/synchrona.py
+++ b/app/python/synchrona/synchrona.py
@@ -307,6 +307,17 @@ def read_channel():
     ret_dict["mode"] = selected_usecase
     ret_dict["input_priorities"] = get_input_priorities(d, hmc7044_prio)
 
+    # check ad9545 input references status
+    ret_dict["pps"] = False
+    ret_dict["ref_in"] = False
+    pps_ref = read_debug_attr('/sys/kernel/debug/clk/Ref-BB-Div/Ref-BB-Div')
+    if pps_ref is not None and "Valid" in pps_ref:
+        ret_dict["pps"] = True
+
+    ref_in_ref = read_debug_attr('/sys/kernel/debug/clk/Ref-B-Div/Ref-B-Div')
+    if ref_in_ref is not None and "Valid" in ref_in_ref:
+        ret_dict["ref_in"] = True
+
     return ret_dict
 
 

--- a/app/python/synchrona/synchrona.py
+++ b/app/python/synchrona/synchrona.py
@@ -129,9 +129,6 @@ def get_input_ref_status(input_ref):
     if hmc_status is None:
         return
 
-    if "PLL1 & PLL2 Locked" in hmc_status:
-        input_ref.locked = True
-
     try:
          hmc7044_ref = hmc_status.split("CLKIN")[1].split(" @")[0]
     except IndexError as e:
@@ -143,26 +140,37 @@ def get_input_ref_status(input_ref):
     elif hmc7044_ref == "1":
         input_ref.ref = "REF_CLK"
     elif hmc7044_ref == "2":
-        try:
-            pll0_status = read_debug_attr('/sys/kernel/debug/clk/PLL0/PLL0')
-            profile = pll0_status.split("Profile Number: ")[1].split("\n")[0]
-            dts = dt.dt(dt_source="local_file", local_dt_filepath="/boot/overlays/rpi-ad9545-hmc7044.dtbo",
-                        arch="arm")
-            ad9545 = dts.get_node_by_compatible("adi,ad9545")[0]
-            pll_node = ad9545.get_subnode("pll-clk@0")
-            pll_profile = pll_node.get_subnode("profile@" + profile)
-        except:
-            print(trace.print_exc())
-        else:
-            pll_source = read_attr(pll_profile, "adi,pll-source")
-            if pll_source == 3:
-                input_ref.ref = "PPS"
-            elif pll_source == 2:
-                input_ref.ref = "REF_IN"
-            # else just leave ref as "unknown"
+        pll0_status = read_debug_attr('/sys/kernel/debug/clk/PLL0/PLL0')
+        if pll0_status is None:
+            return
+        if "Freerun Mode: On" in pll0_status:
+            input_ref.ref = "OCXO"
+        elif "Holdover Mode: On" in pll0_status:
+            input_ref.ref = "Holdover"
+        elif "PLL status: Locked" in pll0_status:
+            # if PLL is locked is it safe to assume that the profile is on?!
+            try:
+                profile = pll0_status.split("Profile Number: ")[1].split("\n")[0]
+                dts = dt.dt(dt_source="local_file",
+                            local_dt_filepath="/boot/overlays/rpi-ad9545-hmc7044.dtbo", arch="arm")
+                ad9545 = dts.get_node_by_compatible("adi,ad9545")[0]
+                pll_node = ad9545.get_subnode("pll-clk@0")
+                pll_profile = pll_node.get_subnode("profile@" + profile)
+            except:
+                print(trace.print_exc())
+            else:
+                pll_source = read_attr(pll_profile, "adi,pll-source")
+                if pll_source == 3:
+                    input_ref.ref = "PPS"
+                elif pll_source == 2:
+                    input_ref.ref = "REF_IN"
+                # else just leave ref as "Unknown"
     else:
         # Just assume we are using CLKIN0 which should never happen
         input_ref.ref = "P_CH3"
+
+    if "PLL1 & PLL2 Locked" in hmc_status and input_ref.ref != "Unknown":
+        input_ref.locked = True
 
 def read_hmc7044_status():
     context = iio.Context('local:')


### PR DESCRIPTION
The main goal of this PR is to refactor how the input references are being reported when the ad9545 is the input being used by the hmc7044 chip. Hence, if the device is in Free Run mode, we report that OCXO is the internal reference being used with a flashing green LED. In this case we flash the LED since both PLLs are running in open loop and the signal accuracy/stability are dependent on the system clock which in turns heavily relies on OCXO. Note that this should still be very stable but not as stable as when running in close loop and hence the slight different report with the flashing LED.  

On holdover mode, the device is working in a very similar way but in this case, we report it as an "Alarm" because this means that we had a valid reference and lost it (so the device enters in this mode). An alert message is also shown.

The rest of the changes are mainly focused in improving the status of the meaningful elements of the block diagram in the advanced tab.