### PR TITLE
app: js: synchrona: improve PPL2 frequency calculation

### DIFF
--- a/app/js/synchrona.js
+++ b/app/js/synchrona.js
@@ -723,7 +723,10 @@ function updateCoarseDelayRange(doc, chId, pll2Freq) {
 }
 
 function updateValuesGeneral(data) {
-    pll2Freq = data["channels"][0].frequency * data["channels"][0].divider;
+    /* find the first enabled channel so that we should get an exact PLL2 freq */
+    const idx = data["channels"].findIndex((elem) => elem.enable == true);
+    pll2Freq = data["channels"][idx].frequency * data["channels"][idx].divider;
+
     for (let i = 1; i <= 14; i++) {
         let ch = data["channels"][i-1];
         document.getElementById(`mode${i}`).textContent = ch.mode;
@@ -805,7 +808,9 @@ function update_input_references_status(vcxo, pps, ref_in) {
 }
 
 function updateValuesAdvanced(data) {
-    pll2Freq = data["channels"][0].frequency * data["channels"][0].divider;
+    /* find the first enabled channel so that we should get an exact PLL2 freq */
+    const idx = data["channels"].findIndex((elem) => elem.enable == true);
+    pll2Freq = data["channels"][idx].frequency * data["channels"][idx].divider;
 
     if (data["mode"] === "zerodelay") {
         document.getElementById('cbxusecase').value = "1PPS";


### PR DESCRIPTION
The calculation of the PLL2 frequency was just getting channel 0 and
multiply it's frequency with it's divider. However, if the channel is
not enabled, that calculation won't exactly match the PLL2 frequency due
to integer approximations. Most likely, the approximated value won't really
have any side effect on the coarse delay calculation but better not to risk
it and do things properly. Thus, we find out the first *enabled* channel
and then calculate the PLL2 frequency.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>