### PR TITLE
fix dhcp settings

### DIFF
--- a/config/dhcpcd.conf
+++ b/config/dhcpcd.conf
@@ -14,3 +14,4 @@ nohook lookup-hostname
 interface eth0
 static ip_address=192.168.2.1/24
 static routers=192.168.2.1
+

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -86,6 +86,8 @@ function saveDHCPConfig($status)
         // remove dhcp + dnsmasq configs for selected interface
         $return = removeDHCPConfig($iface,$status);
         $return = removeDnsmasqConfig($iface,$status);
+    } else if ($_POST['adapter-ip'] == "dhcp") {
+        $return = removeDHCPConfig($iface,$status);
     } else {
         $errors = validateDHCPInput();
         if (empty($errors)) {
@@ -203,7 +205,7 @@ function updateDnsmasqConfig($iface,$status)
         $ip = $staticLeases[$i]['ip'];
         $comment = $staticLeases[$i]['comment'];
         $config .= "dhcp-host=$mac,$ip # $comment".PHP_EOL;
-    } 
+    }
     if ($_POST['no-resolv'] == "1") {
         $config .= "no-resolv".PHP_EOL;
     }

--- a/templates/dhcp/general.php
+++ b/templates/dhcp/general.php
@@ -12,7 +12,7 @@
     <div class="form-group col-md-6">
       <div class="btn-group" data-toggle="buttons">
         <label class="btn btn-light active" checked onclick="setDHCPToggles(false)">
-          <input type="radio" name="adapter-ip" id="chkdhcp" autocomplete="off"> DHCP
+          <input type="radio" name="adapter-ip" value="dhcp" id="chkdhcp" autocomplete="off"> DHCP
         </label>
         <label class="btn btn-light" onclick="setDHCPToggles(true)">
           <input type="radio" name="adapter-ip" id="chkstatic" autocomplete="off"> Static IP
@@ -81,7 +81,7 @@
       </div>
      </div>
   </div>
-  
+
   <div class="row">
     <div class="form-group col-md-6">
       <label for="code"><?php echo _("Starting IP Address"); ?></label>


### PR DESCRIPTION
This PR fixes changing between static vs dynamic IP without having to add dnsmask settings. A small fix on the default dhcpcd conf file was also needed for things to work after a fresh installation. 